### PR TITLE
Save Playlist Selection in Local Storage

### DIFF
--- a/src/pages/ShufflePlayer.js
+++ b/src/pages/ShufflePlayer.js
@@ -13,7 +13,11 @@ function ShufflePlayer() {
   const [playlists,           setPlaylists]           = useState([])
   const [currentVideo,        setCurrentVideo]        = useState({})
   const [playedVideos,        setPlayedVideos]        = useState([])
-  const [selectedPlaylistIds, setSelectedPlaylistIds] = useState([])
+  const [selectedPlaylistIds, setSelectedPlaylistIds] = useState(() => {
+    const saved = localStorage.getItem("selectedPlaylistIds");
+    const initialValue = JSON.parse(saved);
+    return initialValue || [];
+  })
   const [repeatVideo,         setRepeatVideo]         = useState(false)
   const [hideVideo,           setHideVideo]           = useState(true)
   const [hideDescription,     setHideDescription]     = useState(true)
@@ -21,10 +25,19 @@ function ShufflePlayer() {
   const [videosResult, fetchPlaylistVideos] = useVideoHook(selectedPlaylistIds) 
   useEffect(loadPlaylists, [])
   useEffect(pickNextVideo, [videosResult])
-
+  useEffect(() => {
+    localStorage.setItem("selectedPlaylistIds", JSON.stringify(selectedPlaylistIds));
+  }, [selectedPlaylistIds]);
+  
   function loadPlaylists() {
     axios.get(AppConstants.APIEndpoints.TRACKED_PLAYLISTS)
-      .then(response => setPlaylists(response.data))
+      .then(response => {
+        response.data = response.data.map(item => ({
+          ...item,
+          is_default: selectedPlaylistIds.includes(item.playlist_id)
+        }))
+        setPlaylists(response.data)
+      })
       .catch(error => console.log(`Couldn't retrieve tracked playlists! ${error}`))
   }
 

--- a/src/pages/ShufflePlayer.js
+++ b/src/pages/ShufflePlayer.js
@@ -34,7 +34,7 @@ function ShufflePlayer() {
       .then(response => {
         response.data = response.data.map(item => ({
           ...item,
-          is_default: selectedPlaylistIds.includes(item.playlist_id)
+          is_default: selectedPlaylistIds.length > 0 ? selectedPlaylistIds.includes(item.playlist_id) : item.is_default
         }))
         setPlaylists(response.data)
       })

--- a/src/pages/ShufflePlayer.js
+++ b/src/pages/ShufflePlayer.js
@@ -23,12 +23,24 @@ function ShufflePlayer() {
   const [hideDescription,     setHideDescription]     = useState(true)
   
   const [videosResult, fetchPlaylistVideos] = useVideoHook(selectedPlaylistIds) 
-  useEffect(loadPlaylists, [])
   useEffect(pickNextVideo, [videosResult])
   useEffect(() => {
     localStorage.setItem("selectedPlaylistIds", JSON.stringify(selectedPlaylistIds));
   }, [selectedPlaylistIds]);
   
+  useCallbackOnce(loadPlaylists)
+
+  function useCallbackOnce(callbackFunction, condition = true) {
+    const isCalledRef = React.useRef(false);
+  
+    React.useEffect(() => {
+      if (condition && !isCalledRef.current) {
+        isCalledRef.current = true;
+        callbackFunction();
+      }
+    }, [callbackFunction, condition]);
+  }
+
   function loadPlaylists() {
     axios.get(AppConstants.APIEndpoints.TRACKED_PLAYLISTS)
       .then(response => {


### PR DESCRIPTION
Default playlists are supported if local storage is not set. On changing the selection in the playlist selector, playlist IDs are saved to localStorage. 

The saved playlist IDs are retrieved on app load and mapped to the loaded playlists to override the default playlist selections. 

This allows a user to have their own default playlist selections.

Default playlists with no local storage item
![image](https://github.com/happy-software/shuffle_youtube_playlist/assets/28936883/6d4bdff8-465f-4c9a-8ec8-822ce6614d25)


With a playlist selected, app reloaded:
![image](https://github.com/happy-software/shuffle_youtube_playlist/assets/28936883/ab57f7a3-35a8-4ad3-b385-f33f028e34cd)
