### PR TITLE
Add git commit sha to index.html for deployed version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ to your local server.
 ## Run tests locally
 
 `yarn test`
+
+## Deployment
+
+Deployment is done via [gh-pages](https://github.com/tschaub/gh-pages). This publishes files to a `gh-pages` branch on GitHub. 
+
+This is done by the [deploy.yml](.github/workflows/deploy.yml) GitHub Action, which runs automatically on merges to the main branch, or can be manually called in GitHub UI on any branch.
+
+The latest commit SHA of the branch that is deployed will be recorded in a `meta` tag with name `ui-version` in the index.html of the deployed website.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Shuffle Youtube Playlist
+- [Local Development](#local-development)
+  - [Setup](#setup)
+  - [Run App](#run-app)
+  - [Run Tests](#run-tests)
+- [Deployment](#deployment)
+- [Helpful Links](#helpful-links)
+
+# Local Development
 
 ## Setup
 
@@ -6,20 +13,25 @@
 
 2. Run `yarn` to install required packages.
 
-## Running a development server
-`yarn start`
+## Run App
 
-If you're running the backend locally as well, then make sure you update `AppConstants` to point
-to your local server.
+Run `yarn start` in the terminal to start the app
 
-## Run tests locally
+If you're running the backend Happy Youtube Watcher locally as well, update `AppConstants` to point to your local server.
 
-`yarn test`
+## Run Tests
 
-## Deployment
+Run `yarn test` to test the app.
+
+# Deployment
 
 Deployment is done via [gh-pages](https://github.com/tschaub/gh-pages). This publishes files to a `gh-pages` branch on GitHub. 
 
-This is done by the [deploy.yml](.github/workflows/deploy.yml) GitHub Action, which runs automatically on merges to the main branch, or can be manually called in GitHub UI on any branch.
+The [deploy.yml](.github/workflows/deploy.yml) GitHub Action runs automatically on merges to the main branch, or can be manually called on any branch via the GitHub website.
 
-The latest commit SHA of the branch that is deployed will be recorded in a `meta` tag with name `ui-version` in the index.html of the deployed website.
+The latest commit SHA of the branch that is deployed will be recorded in a `meta` tag with name `ui-version` in the index.html of the app.
+
+# Helpful Links
+
+- [React Player](https://github.com/cookpete/react-player), used to interface with Youtube
+- [Youtube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference), used to control some features of the Youtube player

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "react-search-field": "github:ras1/react-search-field#2.0.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts start",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts build",
     "test": "jest",
     "eject": "react-scripts eject",
     "predeploy": "yarn build",

--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <meta name="apple-mobile-web-app-title" content="Shuffle YT">
-    <meta name="application-name" content="Shuffle YT">
-    <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Hebron's Youtube Shuffler" />
-    <title>Shuffle Youtube Playlists</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app. Sorry.</noscript>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <meta name="apple-mobile-web-app-title" content="Shuffle YT">
+  <meta name="application-name" content="Shuffle YT">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Hebron's Youtube Shuffler" />
+  <meta name="ui-version" content="%REACT_APP_GIT_SHA%">
+  <title>Shuffle Youtube Playlists</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app. Sorry.</noscript>
+  <div id="root"></div>
+</body>
+
 </html>


### PR DESCRIPTION
When a version of the application is deployed, the latest commit SHA of the deployed branch will be stored in a meta tag in index.html

Example: 

This branch has latest commit id/sha = b6d2e0868dcd1bdb2c7e7a16d5c4810c1fb52a58. 
The branch was deployed to the website, reviewing the ui-version tag in html source shows:
![image](https://github.com/user-attachments/assets/897efdf0-c29e-45dd-8c39-7929cd944c2f)

